### PR TITLE
Upgrade bridge qos

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -29,6 +29,7 @@ Broker:
 - mosquitto_db_dump tool can now output some stats on clients.
 - perform utf-8 validation on incoming will, subscription and unsubscription
   topics.
+- Add upgrade_bridge_qos option in configuration. Closes #203.
 
 Client library:
 - Outgoing messages with QoS>1 are no longer retried after a timeout period.

--- a/man/mosquitto.conf.5.xml
+++ b/man/mosquitto.conf.5.xml
@@ -577,6 +577,20 @@
 				</listitem>
 			</varlistentry>
 			<varlistentry>
+				<term><option>upgrade_bridge_qos</option> [ true | false ]</term>
+				<listitem>
+					<para>If <option>upgrade_bridge_qos</option> is set to
+						<replaceable>true</replaceable>, messages
+						delivered to another broker on a bridge will be published with
+						the QoS level specified for that bridge. If set to
+						<replaceable>false</replaceable>, then the QoS level specified
+						for the bridge is used as an upper limit respect to the QoS of
+						the original incoming messages.
+						Defaults to <replaceable>false</replaceable>.</para>
+					<para>Reloaded on reload signal.</para>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
 				<term><option>user</option> <replaceable>username</replaceable></term>
 				<listitem>
 					<para>When run as root, change to this user and its primary

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -118,6 +118,14 @@
 # This is a non-standard option explicitly disallowed by the spec.
 #upgrade_outgoing_qos false
 
+# This option allows to specify the QoS with which the messages delivered to
+# another broker through a bridge will be published, regardless the QoS level
+# of the original incoming messages. The desired QoS is specified for each
+# bridge in the bridge connection section.
+# If this option is disabled, then the QoS level specified for a bridge will be
+# used as an upper limit respect to the QoS of the original incoming messages.
+#upgrade_bridge_qos false
+
 # =================================================================
 # Default listener
 # =================================================================

--- a/src/conf.c
+++ b/src/conf.c
@@ -159,6 +159,7 @@ static void config__init_reload(struct mosquitto__config *config)
 	config->queue_qos0_messages = false;
 	config->sys_interval = 10;
 	config->upgrade_outgoing_qos = false;
+	config->upgrade_bridge_qos = false;
 	if(config->auth_plugins){
 		for(i=0; i<config->auth_plugin_count; i++){
 			plug = &config->auth_plugins[i];
@@ -1716,6 +1717,8 @@ int config__read_file_core(struct mosquitto__config *config, bool reload, const 
 #endif
 				}else if(!strcmp(token, "upgrade_outgoing_qos")){
 					if(conf__parse_bool(&token, token, &config->upgrade_outgoing_qos, saveptr)) return MOSQ_ERR_INVAL;
+				}else if(!strcmp(token, "upgrade_bridge_qos")){
+					if(conf__parse_bool(&token, token, &config->upgrade_bridge_qos, saveptr)) return MOSQ_ERR_INVAL; 
 				}else if(!strcmp(token, "use_identity_as_username")){
 #ifdef WITH_TLS
 					if(reload) continue; // Listeners not valid for reloading.

--- a/src/mosquitto_broker.h
+++ b/src/mosquitto_broker.h
@@ -214,6 +214,7 @@ struct mosquitto__config {
 	bool queue_qos0_messages;
 	int sys_interval;
 	bool upgrade_outgoing_qos;
+	bool upgrade_bridge_qos;
 	char *user;
 	bool verbose;
 #ifdef WITH_WEBSOCKETS

--- a/src/subs.c
+++ b/src/subs.c
@@ -109,7 +109,7 @@ static int subs__process(struct mosquitto_db *db, struct mosquitto__subhier *hie
 		}else if(rc2 == MOSQ_ERR_SUCCESS){
 			client_qos = leaf->qos;
 
-			if(db->config->upgrade_outgoing_qos){
+			if((db->config->upgrade_bridge_qos && leaf->context->is_bridge) || db->config->upgrade_outgoing_qos){
 				msg_qos = client_qos;
 			}else{
 				if(qos > client_qos){

--- a/src/websockets.c
+++ b/src/websockets.c
@@ -200,7 +200,7 @@ static int callback_mqtt(struct libwebsocket_context *context,
 				return -1;
 			}
 
-			mqtt3_db_message_write(db, mosq);
+			db__message_write(db, mosq);
 
 			if(mosq->out_packet && !mosq->current_out_packet){
 				mosq->current_out_packet = mosq->out_packet;


### PR DESCRIPTION
Close issue #203.
Fix a compilation error (when websocket support is enabled) in calling a db function.
Please, check the correctness of documentation in `mosquitto.conf` and `man/mosquitto.conf.5.xml`.
